### PR TITLE
fix: (INF-133) for code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/app/controllers/vpn_devices_controller.rb
+++ b/app/controllers/vpn_devices_controller.rb
@@ -50,7 +50,12 @@ class VpnDevicesController < ApplicationController
   # POST /vpn_devices or /vpn_devices.json
   def create
     config_file = params[:config_file]
-    output, status = Open3.capture2e("sudo wg-quick up #{config_file}")
+    # Accept only a valid WireGuard interface name (alphanumeric, underscores)
+    unless config_file.is_a?(String) && config_file.match?(/\A[\w\-]+\z/)
+      redirect_to new_vpn_device_path, alert: "Invalid WireGuard config file/interface name."
+      return
+    end
+    output, status = Open3.capture2e(['sudo', 'wg-quick', 'up', config_file])
 
     if status.success?
       redirect_to vpn_devices_path, notice: 'WireGuard interface created successfully.'

--- a/app/controllers/vpn_devices_controller.rb
+++ b/app/controllers/vpn_devices_controller.rb
@@ -1,4 +1,6 @@
 class VpnDevicesController < ApplicationController
+  # Only allow these WireGuard interfaces to be managed by this controller
+  ALLOWED_WG_INTERFACES = %w[wg0 wg1]
   before_action :set_vpn_device, only: %i[show edit update destroy]
   before_action :require_login
   after_action :update_wireguard_config, only: %i[update destroy]
@@ -53,6 +55,10 @@ class VpnDevicesController < ApplicationController
     # Accept only a valid WireGuard interface name (alphanumeric, underscores)
     unless config_file.is_a?(String) && config_file.match?(/\A[\w\-]+\z/)
       redirect_to new_vpn_device_path, alert: "Invalid WireGuard config file/interface name."
+      return
+    end
+    unless ALLOWED_WG_INTERFACES.include?(config_file)
+      redirect_to new_vpn_device_path, alert: "WireGuard interface not allowed."
       return
     end
     output, status = Open3.capture2e(['sudo', 'wg-quick', 'up', config_file])


### PR DESCRIPTION
Potential fix for [https://github.com/flowaccount/gate-wireguard/security/code-scanning/1](https://github.com/flowaccount/gate-wireguard/security/code-scanning/1)

---
## Jira:
https://flowaccount.atlassian.net/browse/INF-133

To fix this problem, we must ensure that user input cannot result in command injection. The safest way is to avoid shell interpolation altogether by passing an array of command arguments to `Open3.capture2e`, so no shell parsing occurs. Additionally, we should validate the provided `config_file` value—ensure it corresponds only to permitted filenames, with no path traversal or arbitrary string execution.

Recommended steps:
- Replace `"sudo wg-quick up #{config_file}"` (which passes through the shell) with `["sudo", "wg-quick", "up", config_file]` (array form—no shell parsing).
- Add input validation for `config_file`. Only allow files with a restricted set of values, or at minimum, allow only legitimate interface names (`wg-quick up` works on interface names, not paths).
- Reject values containing path traversal (e.g., slashes), spaces, or command metacharacters; ideally, maintain an allowlist.

Changes:
- In method `create`, sanitize and validate `config_file` before use.
- Update the line to pass argument array to `Open3.capture2e`.
- Optionally, add a helper method to validate interface/config file name.

Required: code edit in app/controllers/vpn_devices_controller.rb (lines 51-60 region); no new dependencies needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
