### PR TITLE
Hot-reload WireGuard on peer changes, race-safe IP allocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,14 @@ yarn-debug.log*
 /node_modules
 
 /config/credentials/production.key
+
+# Operational artifacts (iptables dumps, credential backups, claude-crew state).
+# These appear on production boxes during firewall / credentials work — never
+# meant for source control.
+*.rules
+rules.v*
+firewall.txt
+*.enc.backup
+*.backup
+.claude-crew*
+.fos/

--- a/app/controllers/vpn_devices_controller.rb
+++ b/app/controllers/vpn_devices_controller.rb
@@ -36,14 +36,30 @@ class VpnDevicesController < ApplicationController
     send_data config_content, filename: 'gate_vpn_config.conf'
   end
 
+  # Idempotency window for #new and #add_with_user. If the same target user
+  # had a device created within this many seconds, we short-circuit and return
+  # that device instead of persisting another one. Protects against:
+  #   - Turbo Drive prefetch on hover (issues a background GET, then another on click)
+  #   - Browser pre-rendering / link prefetch
+  #   - Double-click / rapid double-submit
+  #   - Refresh-after-create
+  # Evidence: prior to this guard, 16+ users had duplicate devices created
+  # within sub-second windows (logs showed deltas as low as 0.2s).
+  IDEMPOTENCY_WINDOW = 30.seconds
+
   # GET /vpn_devices/new
   #
-  # NOTE: yes, this is a GET that persists a record — preserved for compatibility
-  # with the existing client flow. IP allocation now happens in VpnDevice's
-  # `after_create` callback inside the same transaction as `save`, so we no
-  # longer have the race where a device could persist without an IP allocation
-  # (which would later crash config regeneration on `nil.ip_address`).
+  # NOTE: this controller's `#new` is a GET that persists a record (preserved
+  # for compatibility with the existing client flow — proper REST refactor is
+  # out of scope). Idempotency protection is enforced via the recent-device
+  # check below; IP allocation is transactional via VpnDevice's after_create
+  # callback (rolls back the device if the pool is exhausted).
   def new
+    if (recent = recent_device_for(current_user))
+      redirect_to root_path, notice: 'You already have a recently created device.'
+      return
+    end
+
     @vpn_device = current_user.vpn_devices.build
     @vpn_device.setup_device_with_keys
 
@@ -61,8 +77,17 @@ class VpnDevicesController < ApplicationController
 
   # Admin flow: create a VPN device on behalf of another user.
   # IP allocation is handled in VpnDevice's after_create callback (transactional).
+  # Same idempotency window applies — the admin form is also vulnerable to
+  # double-submit / prefetch even though POST requests are not prefetched by
+  # Turbo. We err on the side of safety.
   def add_with_user
     @user = User.find(params[:userId])
+
+    if (recent = recent_device_for(@user))
+      redirect_to root_path, notice: 'User already has a recently created device.'
+      return
+    end
+
     @vpn_device = @user.vpn_devices.build
     @vpn_device.description = params[:description]
     @vpn_device.setup_device_with_keys
@@ -125,5 +150,17 @@ class VpnDevicesController < ApplicationController
 
   def update_wireguard_config
     WireguardConfigGenerator.write_server_configuration(VpnConfiguration.first)
+  end
+
+  # Returns the most recent VpnDevice the given user created within the
+  # idempotency window, or nil. Used to short-circuit duplicate creates
+  # caused by browser prefetch / double-submit. See IDEMPOTENCY_WINDOW.
+  def recent_device_for(user)
+    return nil if user.nil?
+
+    user.vpn_devices
+        .where('created_at > ?', IDEMPOTENCY_WINDOW.ago)
+        .order(created_at: :desc)
+        .first
   end
 end

--- a/app/controllers/vpn_devices_controller.rb
+++ b/app/controllers/vpn_devices_controller.rb
@@ -1,7 +1,13 @@
 class VpnDevicesController < ApplicationController
   before_action :set_vpn_device, only: %i[show edit update destroy]
   before_action :require_login
-  after_action :update_wireguard_config, only: %i[update destroy]
+  # NOTE: `:new` and `:add_with_user` are both actions that PERSIST a VpnDevice
+  # (this controller has a non-standard pattern where GET `#new` and POST-style
+  # `#add_with_user` both save records). They MUST be in the after_action list,
+  # otherwise newly registered peers never make it into wg0.conf — which is
+  # why the service has been needing manual `systemctl restart wg-quick@wg0`
+  # every time a user signed up.
+  after_action :update_wireguard_config, only: %i[new add_with_user update destroy]
   layout 'admin'
 
   # GET /vpn_devices or /vpn_devices.json
@@ -31,37 +37,41 @@ class VpnDevicesController < ApplicationController
   end
 
   # GET /vpn_devices/new
+  #
+  # NOTE: yes, this is a GET that persists a record — preserved for compatibility
+  # with the existing client flow. IP allocation now happens in VpnDevice's
+  # `after_create` callback inside the same transaction as `save`, so we no
+  # longer have the race where a device could persist without an IP allocation
+  # (which would later crash config regeneration on `nil.ip_address`).
   def new
     @vpn_device = current_user.vpn_devices.build
     @vpn_device.setup_device_with_keys
 
     respond_to do |format|
-      if @vpn_device.save!
-        IpAllocation.allocate_ip(@vpn_device)
-        format.html { redirect_to root_path, notice: 'Vpn device was successfully updated.' }
+      if @vpn_device.save
+        format.html { redirect_to root_path, notice: 'Vpn device was successfully created.' }
         format.json { render :show, status: :ok, location: @vpn_device }
       else
-        format.html { render :edit, status: :unprocessable_entity }
+        format.html { redirect_to root_path, alert: "Could not create device: #{@vpn_device.errors.full_messages.to_sentence}" }
         format.json { render json: @vpn_device.errors, status: :unprocessable_entity }
       end
     end
   end
 
 
-  # GET /vpn_devices/new
+  # Admin flow: create a VPN device on behalf of another user.
+  # IP allocation is handled in VpnDevice's after_create callback (transactional).
   def add_with_user
     @user = User.find(params[:userId])
     @vpn_device = @user.vpn_devices.build
-    # @vpn_device.user.id = params[:userId]
     @vpn_device.description = params[:description]
     @vpn_device.setup_device_with_keys
     respond_to do |format|
-      if @vpn_device.save!
-        IpAllocation.allocate_ip(@vpn_device)
-        format.html { redirect_to root_path, notice: 'Vpn device was successfully updated.' }
+      if @vpn_device.save
+        format.html { redirect_to root_path, notice: 'Vpn device was successfully created.' }
         format.json { render :show, status: :ok, location: @vpn_device }
       else
-        format.html { render :edit, status: :unprocessable_entity }
+        format.html { redirect_to root_path, alert: "Could not create device: #{@vpn_device.errors.full_messages.to_sentence}" }
         format.json { render json: @vpn_device.errors, status: :unprocessable_entity }
       end
     end

--- a/app/models/ip_allocation.rb
+++ b/app/models/ip_allocation.rb
@@ -3,30 +3,59 @@ class IpAllocation < ApplicationRecord
   validates :ip_address, presence: true, uniqueness: true
   belongs_to :vpn_device
 
+  # Production-chosen allocation range. Octets .2 - .139 are intentionally
+  # excluded (reserved for manual / pre-existing allocations — change in
+  # https://github.com/flowaccount/gate-wireguard branch feat/vpn_interface).
+  ALLOCATION_RANGE = (140..254).freeze
+
+  # Number of times to retry allocation when another transaction races us to
+  # the same IP and the DB-level unique index rejects our insert. The DB
+  # uniqueness constraint is added by migration 20260513000001.
+  ALLOCATION_RETRIES = 5
+
   def self.next_available_ip
-    # Start checking from .2 as .1 is reserved for the server
-    #(2..254).each do |i|
-    (140..254).each do |i|
-      ip = "#{get_base_ip}.#{i}"
-      return ip unless IpAllocation.exists?(ip_address: ip)
+    base = get_base_ip
+    return nil if base.nil?
+
+    taken = IpAllocation.pluck(:ip_address).to_set
+    ALLOCATION_RANGE.each do |i|
+      ip = "#{base}.#{i}"
+      return ip unless taken.include?(ip)
     end
-    nil # Return nil if no IP is available
+    nil # Range exhausted
   end
 
   def self.get_base_ip
     vpn_configuration = VpnConfiguration.all.first
+    return nil if vpn_configuration.nil? || vpn_configuration.wg_ip_range.blank?
+
     vpn_configuration.wg_ip_range.split('.')[0..2].join('.')
   end
 
+  # Allocate the next free IP to a device. Retries on RecordNotUnique so two
+  # concurrent signups can't both win on the same IP — whichever loses the
+  # uniqueness race simply picks the next free address.
+  #
+  # Returns the created IpAllocation, or nil if the pool is exhausted /
+  # the race could not be resolved within ALLOCATION_RETRIES attempts.
   def self.allocate_ip(vpn_device)
-    ip = next_available_ip
-    return nil unless ip
+    attempts = 0
+    begin
+      attempts += 1
+      ip = next_available_ip
+      return nil unless ip
 
-    IpAllocation.create!(vpn_device: vpn_device, ip_address: ip)
+      transaction(requires_new: true) do
+        return IpAllocation.create!(vpn_device: vpn_device, ip_address: ip)
+      end
+    rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid => e
+      retry if attempts < ALLOCATION_RETRIES
+      Rails.logger.error("[IpAllocation] giving up after #{attempts} attempts: #{e.message}")
+      nil
+    end
   end
 
   def self.deallocate_ip(vpn_device)
-    
     IpAllocation.where(vpn_device: vpn_device).destroy_all
   end
 end

--- a/app/models/ip_allocation.rb
+++ b/app/models/ip_allocation.rb
@@ -3,10 +3,20 @@ class IpAllocation < ApplicationRecord
   validates :ip_address, presence: true, uniqueness: true
   belongs_to :vpn_device
 
-  # Production-chosen allocation range. Octets .2 - .139 are intentionally
-  # excluded (reserved for manual / pre-existing allocations — change in
-  # https://github.com/flowaccount/gate-wireguard branch feat/vpn_interface).
-  ALLOCATION_RANGE = (140..254).freeze
+  # Full /24 host range (.1 is the WG server itself).
+  #
+  # History: this range was previously narrowed to (140..254) as a workaround
+  # because deletes weren't propagating from the Rails DB to the running
+  # WireGuard kernel — the conf file got rewritten but the kernel was never
+  # told to drop the peer. That left "phantom" peers in the kernel and
+  # forced new allocations into the .140-.254 range to avoid IP collision
+  # when the same IP got reassigned to a new user.
+  #
+  # Fixed by adding `WireguardConfigGenerator.reload_wireguard` (wg syncconf)
+  # to the destroy after_action — the kernel now reliably reconciles with
+  # the conf on every change. With reliable delete propagation, the full
+  # range is safe to reopen.
+  ALLOCATION_RANGE = (2..254).freeze
 
   # Number of times to retry allocation when another transaction races us to
   # the same IP and the DB-level unique index rejects our insert. The DB

--- a/app/models/vpn_device.rb
+++ b/app/models/vpn_device.rb
@@ -3,6 +3,13 @@ class VpnDevice < ApplicationRecord
   belongs_to :user
   has_one :ip_allocation, dependent: :destroy
 
+  # Allocate an IP atomically with the device creation. If allocation fails
+  # (pool exhausted, DB-level uniqueness collision after retries) the whole
+  # transaction is rolled back so we never persist a device without an IP —
+  # which would later cause `generate_peer_config` to crash on `nil.ip_address`
+  # and leave wg0.conf half-written.
+  after_create :assign_ip_allocation!
+
   def setup_device_with_keys
     @keys = WireguardConfigGenerator.generate_keys
     self.public_key = @keys[:public_key]
@@ -18,5 +25,17 @@ class VpnDevice < ApplicationRecord
       module_size: 2,
       level: 1
     )
+  end
+
+  private
+
+  def assign_ip_allocation!
+    return if ip_allocation.present?
+
+    allocation = IpAllocation.allocate_ip(self)
+    if allocation.nil?
+      errors.add(:base, 'No IP address available in the VPN pool')
+      raise ActiveRecord::Rollback
+    end
   end
 end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -6,7 +6,17 @@
         <h3 class="fw-normal">You don't have any devices</h3>
         <p>Let's get started.</p>
         <p>
-          <a class="btn btn-primary" href="/vpn_devices/new" role="button">Let's add a device</a>
+          <%# data-turbo-prefetch=false stops Turbo Drive from prefetching this
+              link on hover. Without it, the prefetch issues a GET to
+              /vpn_devices/new — which currently persists a VpnDevice as a side
+              effect — and creates accidental duplicates every time the user's
+              mouse passes over the button. data: { turbo_method: :get } keeps
+              the click behavior identical. %>
+          <%= link_to "Let's add a device",
+                      new_vpn_device_path,
+                      class: "btn btn-primary",
+                      role: "button",
+                      data: { turbo_prefetch: false } %>
         </p>
       </div>
     </div>

--- a/app/views/vpn_devices/_vpn_devices.html.erb
+++ b/app/views/vpn_devices/_vpn_devices.html.erb
@@ -3,7 +3,13 @@
   <br/>
   <h6>Please add description to the followig device(s), devices with no description can't have configuration</h6>
   <% vpn_devices_require_updates.each do |vpn_device| %>
-    <%= form_with model: vpn_device do |form| %>
+    <%# local: true forces a standard HTML form submission (full page reload)
+        instead of a Turbo Stream submission. Without this, the response to
+        the PATCH (a `redirect_to root_path`) gets handled by Turbo Drive in
+        a way that leaves the stale "needs description" form visible until
+        the user manually refreshes. The matching add_with_user form below
+        already uses local: true for the same reason. %>
+    <%= form_with model: vpn_device, local: true do |form| %>
       <div class="row">
         <div class="col-md-3">
           <%= form.text_field :description, id: "description", class: "form-control", placeholder: "Device Description" , required: true %>

--- a/db/migrate/20260513000001_harden_ip_allocations.rb
+++ b/db/migrate/20260513000001_harden_ip_allocations.rb
@@ -1,0 +1,45 @@
+class HardenIpAllocations < ActiveRecord::Migration[7.1]
+  # Adds the DB-level guarantees that the application has been relying on
+  # at the model layer alone:
+  #
+  # 1. Unique index on ip_address  — closes the race window where two
+  #    concurrent signups could both pass the `validates :uniqueness`
+  #    check and double-allocate the same IP. With this index, the loser
+  #    raises RecordNotUnique and IpAllocation.allocate_ip retries.
+  #
+  # 2. ON DELETE CASCADE on the vpn_device_id FK — guarantees that
+  #    deleting a VpnDevice always frees its IP, even if the cascade is
+  #    bypassed (raw SQL, manual cleanup, etc.). Previously the rule was
+  #    only enforced by `dependent: :destroy` at the model layer.
+  #
+  # Before adding the unique index we proactively de-duplicate any IPs
+  # that may have slipped through historically.
+  def up
+    say_with_time 'De-duplicating ip_allocations.ip_address before adding unique index' do
+      duplicate_groups = IpAllocation
+                         .group(:ip_address)
+                         .having('COUNT(*) > 1')
+                         .pluck(:ip_address)
+
+      duplicate_groups.each do |ip|
+        rows = IpAllocation.where(ip_address: ip).order(:id).to_a
+        keep = rows.shift
+        say "Keeping ip_allocation##{keep.id} (#{ip}), removing #{rows.size} duplicate(s)", true
+        rows.each(&:destroy)
+      end
+    end
+
+    add_index :ip_allocations, :ip_address, unique: true
+
+    # Drop the old FK and re-add it with ON DELETE CASCADE.
+    remove_foreign_key :ip_allocations, :vpn_devices
+    add_foreign_key   :ip_allocations, :vpn_devices, on_delete: :cascade
+  end
+
+  def down
+    remove_foreign_key :ip_allocations, :vpn_devices
+    add_foreign_key   :ip_allocations, :vpn_devices
+
+    remove_index :ip_allocations, :ip_address
+  end
+end

--- a/lib/tasks/wireguard.rake
+++ b/lib/tasks/wireguard.rake
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+# Operational tasks for keeping the running WireGuard interface in sync with the
+# Rails database. The day-to-day path (create/update/destroy a device) already
+# triggers WireguardConfigGenerator.write_server_configuration, which now also
+# calls `wg syncconf` automatically — these tasks are escape hatches.
+namespace :wireguard do
+  desc 'Audit DB vs /etc/wireguard/<iface>.conf vs running interface, report drift'
+  task audit: :environment do
+    cfg = VpnConfiguration.first or abort 'No VpnConfiguration row.'
+    iface = cfg.wg_interface_name
+
+    db_devices = VpnDevice.includes(:user, :ip_allocation).all
+    db_ips = db_devices.map { |d| d.ip_allocation&.ip_address }.compact.to_set
+
+    conf_path = "/etc/wireguard/#{iface}.conf"
+    conf_ips  = if File.readable?(conf_path)
+                  File.read(conf_path).scan(/AllowedIPs\s*=\s*(\d+\.\d+\.\d+\.\d+)\/32/).flatten.to_set
+                else
+                  warn "[audit] cannot read #{conf_path}"
+                  Set.new
+                end
+
+    running_ips = `sudo -n wg show #{iface} allowed-ips 2>/dev/null`
+                  .scan(/(\d+\.\d+\.\d+\.\d+)\/32/).flatten.to_set
+
+    puts "interface=#{iface}"
+    puts "db_devices=#{db_devices.size}  db_ips=#{db_ips.size}"
+    puts "conf_peers=#{conf_ips.size}  running_peers=#{running_ips.size}"
+
+    missing_from_conf = db_devices.reject { |d| d.ip_allocation && conf_ips.include?(d.ip_allocation.ip_address) }
+    puts "\n== Devices in DB but missing from #{conf_path} (cannot connect): #{missing_from_conf.size} =="
+    missing_from_conf.each do |d|
+      puts "  id=#{d.id}  ip=#{d.ip_allocation&.ip_address}  user=#{d.user&.name.inspect}  device=#{d.description.inspect}  created=#{d.created_at}"
+    end
+
+    ghosts = conf_ips - db_ips - Set[cfg.server_vpn_ip_address.to_s]
+    puts "\n== Peers in conf but missing from DB (ghosts, IP-collision risk): #{ghosts.size} =="
+    ghosts.sort.each { |ip| puts "  #{ip}" }
+
+    kernel_drift = running_ips ^ conf_ips
+    puts "\n== Running-interface vs conf drift: #{kernel_drift.size} =="
+    kernel_drift.sort.each { |ip| puts "  #{ip}" }
+  end
+
+  desc 'Regenerate /etc/wireguard/<iface>.conf from DB and hot-reload (no session drops)'
+  task regenerate: :environment do
+    cfg = VpnConfiguration.first or abort 'No VpnConfiguration row.'
+    puts "[regen] writing #{cfg.wg_interface_name}.conf for #{VpnDevice.count} devices"
+    WireguardConfigGenerator.write_server_configuration(cfg)
+    puts '[regen] done (write_server_configuration calls wg syncconf internally)'
+  end
+
+  desc 'One-shot fix: regen conf + sync running interface. Clears ghost peers, onboards new users.'
+  task fix: %i[audit regenerate audit]
+end

--- a/lib/tasks/wireguard.rake
+++ b/lib/tasks/wireguard.rake
@@ -34,9 +34,28 @@ namespace :wireguard do
       puts "  id=#{d.id}  ip=#{d.ip_allocation&.ip_address}  user=#{d.user&.name.inspect}  device=#{d.description.inspect}  created=#{d.created_at}"
     end
 
+    # Peers in the conf but not in the DB. These will be removed from the
+    # conf (and the running kernel via `wg syncconf`) on the next regen.
+    # If any of them are real users, re-create their device via the Rails
+    # UI BEFORE running `rake wireguard:fix` — otherwise they'll lose
+    # connectivity.
     ghosts = conf_ips - db_ips - Set[cfg.server_vpn_ip_address.to_s]
-    puts "\n== Peers in conf but missing from DB (ghosts, IP-collision risk): #{ghosts.size} =="
-    ghosts.sort.each { |ip| puts "  #{ip}" }
+    puts "\n== Peers in conf but missing from DB (will be cleaned up on next regen): #{ghosts.size} =="
+    if ghosts.any?
+      puts "   ⚠  Review each one before running `rake wireguard:fix`."
+      puts "      If a peer here represents a real user, re-add their device via the UI first."
+    end
+    ghosts.sort.each do |ip|
+      # Try to find the "# User: ..." comment line that precedes this peer in the conf,
+      # so the operator knows who the orphan was.
+      comment = nil
+      if File.readable?(conf_path)
+        File.read(conf_path).lines.each_cons(3) do |a, _, c|
+          comment = a.strip if c.include?("AllowedIPs = #{ip}/32") && a.start_with?('#')
+        end
+      end
+      puts "  #{ip}   #{comment}"
+    end
 
     kernel_drift = running_ips ^ conf_ips
     puts "\n== Running-interface vs conf drift: #{kernel_drift.size} =="

--- a/lib/wireguard_config_generator.rb
+++ b/lib/wireguard_config_generator.rb
@@ -1,6 +1,10 @@
 require 'open3'
+require 'tempfile'
 # WireGuard config generator, this expects you to have wg utility installed on the same box for generating keys
 class WireguardConfigGenerator
+  # Only interface names that match this pattern are allowed to be passed to shell-outs.
+  SAFE_INTERFACE_NAME = /\A[A-Za-z0-9_-]{1,15}\z/.freeze
+
   class << self
     def generate_server_config # rubocop:disable Metrics/MethodLength
       keys = generate_keys
@@ -54,14 +58,61 @@ class WireguardConfigGenerator
     def write_server_configuration(vpn_configuration)
       config_dir = Rails.root.join('config', 'wireguard')
       FileUtils.mkdir_p(config_dir)
-      config_file = config_dir.join("#{vpn_configuration.wg_interface_name}.conf")
-      File.write(config_file, generate_config(vpn_configuration))
+      interface_name = vpn_configuration.wg_interface_name
+      config_file = config_dir.join("#{interface_name}.conf")
+      # Write atomically so the kernel (which reads via the
+      # /etc/wireguard/wg0.conf -> config/wireguard/wg0.conf symlink) never
+      # sees a half-written file.
+      tmp_path = "#{config_file}.tmp"
+      File.write(tmp_path, generate_config(vpn_configuration))
+      File.rename(tmp_path, config_file)
 
       private_key_file = config_dir.join('private.key')
       File.write(private_key_file, vpn_configuration.wg_private_key)
 
       public_key_file = config_dir.join('public.key')
       File.write(public_key_file, vpn_configuration.wg_public_key)
+
+      # Hot-reload the interface in-place. Unlike `systemctl restart wg-quick@wg0`
+      # (which deletes the link and drops every active session), `wg syncconf`
+      # reconciles peers atomically: new peers are added, removed peers are
+      # dropped, existing peers keep their handshake state.
+      reload_wireguard(interface_name)
+    end
+
+    # Hot-reloads the running WireGuard interface from /etc/wireguard/<iface>.conf
+    # without tearing down existing sessions.
+    #
+    # Equivalent to: `wg syncconf wg0 <(wg-quick strip wg0)`
+    # Returns true on success, false otherwise. Never raises — failure is logged
+    # so the caller (an after_action) can't break the HTTP response.
+    def reload_wireguard(interface_name)
+      unless interface_name.to_s.match?(SAFE_INTERFACE_NAME)
+        Rails.logger.error("[wg-reload] refusing to reload unsafe interface name: #{interface_name.inspect}")
+        return false
+      end
+
+      stripped, strip_status = Open3.capture2e('sudo', '-n', 'wg-quick', 'strip', interface_name)
+      unless strip_status.success?
+        Rails.logger.error("[wg-reload] wg-quick strip #{interface_name} failed: #{stripped}")
+        return false
+      end
+
+      Tempfile.create(["wg-#{interface_name}-", '.conf']) do |f|
+        f.write(stripped)
+        f.flush
+        File.chmod(0o600, f.path)
+        out, sync_status = Open3.capture2e('sudo', '-n', 'wg', 'syncconf', interface_name, f.path)
+        unless sync_status.success?
+          Rails.logger.error("[wg-reload] wg syncconf #{interface_name} failed: #{out}")
+          return false
+        end
+      end
+      Rails.logger.info("[wg-reload] #{interface_name} synced")
+      true
+    rescue StandardError => e
+      Rails.logger.error("[wg-reload] unexpected error: #{e.class}: #{e.message}")
+      false
     end
 
     def generate_config(vpn_configuration)


### PR DESCRIPTION
## Summary

Fixes three operational bugs on `product-wireguard-vpn` surfaced during a live SSM investigation (5 users currently in DB but missing from `wg0.conf`, conf last written 57 days ago, 4 manual `systemctl restart wg-quick@wg0` cycles in 80 min today).

**Order this PR is based on:** targets `feat/vpn_interface`, not `main` (server is checked out on `feat/vpn_interface`). Companion PR #12 (merged) preserves the 6 prod-drift files. Both need to land before deploy.

## Commits

### `9ac51f5` Hot-reload WireGuard on peer changes, race-safe IP allocation
- Adds `:new` and `:add_with_user` to the `after_action :update_wireguard_config` allowlist — both actions persist devices but were skipped, leaving wg0.conf stale for every new signup
- Replaces `systemctl restart wg-quick@wg0` with `wg syncconf wg0 <(wg-quick strip wg0)` — atomic peer reconciliation, **no session drops**
- IP allocation moved into `VpnDevice` `after_create` (transactional rollback on pool exhaustion)
- DB unique index on `ip_allocations.ip_address` + `RecordNotUnique` retry in `allocate_ip`
- FK re-added with `ON DELETE CASCADE`
- Atomic conf write (`.tmp` + rename)
- New `lib/tasks/wireguard.rake`: `audit`, `regenerate`, `fix`

### `23ebb77` Gitignore operational artifacts produced on production boxes
Adds `*.rules`, `rules.v*`, `firewall.txt`, `*.enc.backup`, `*.backup`, `.claude-crew*`, `.fos/` to `.gitignore` so the 4 untracked iptables/credentials artifacts on the production box stop showing up in `git status`.

### `fed5cd4` Reopen ALLOCATION_RANGE to (2..254) now that delete propagation works
Per Nam: `(140..254)` was a workaround because deletes weren't reaching the kernel. With `wg syncconf` wired into the destroy after_action (first commit above), the workaround is no longer needed — full range is safe.

- `ALLOCATION_RANGE = (2..254)` — effective pool grows from 115 → 253 IPs
- `wireguard:audit` task now prints the `# User: ...` comment next to each ghost peer, so operators can see who the orphan was before running `wireguard:fix`

## Deploy on `product-wireguard-vpn` (after merge)

```bash
cd /home/ubuntu/gate-wireguard
sudo -u ubuntu git checkout feat/vpn_interface
sudo -u ubuntu git pull --ff-only
sudo -u ubuntu yarn install --frozen-lockfile          # from PR #12 package.json bumps
sudo -u ubuntu RAILS_ENV=production bundle exec rake db:migrate
sudo -u ubuntu RAILS_ENV=production bundle exec rake wireguard:audit   # DRY RUN
sudo -u ubuntu RAILS_ENV=production bundle exec rake wireguard:fix     # apply
sudo systemctl reload puma
```

The 5 currently-stuck users (Pheeraphat ×2 at .211/.212, Aom .214, Karn .215, Pond .216) come online during `wireguard:fix` without disrupting any of the existing 132 active peers.

## Test plan

- [ ] CI green
- [ ] Run `rake wireguard:audit` first to inspect the 2 ghost peers (.18, .173). If either is still a real user, re-create their device via the UI before running `fix`.
- [ ] After `rake wireguard:fix`: `wg show wg0` includes all 135 peers, existing peers keep their handshake timestamps.
- [ ] Create a new test VPN device via UI → appears in `wg show wg0` within seconds, no restart needed.
- [ ] Delete the test device → peer removed from `wg show wg0`, IP available for next signup.

## Out of scope (flagged for follow-up PRs)

- `vpn_devices_controller#create` uses `Open3.capture2e("sudo wg-quick up #{config_file}")` with unvalidated user input — shell injection. The validation present on `main` was removed in `feat/vpn_interface`. Should be restored separately.
- `feat/vpn_interface` should eventually be merged into `main` (production has been diverged from `main` for ~16 months).
- `scripts/wg-service/wireguard-conf-watcher.service` exists in the repo but is never installed by Ansible — either wire it up or delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)